### PR TITLE
ノート取得件数に上限を設けた

### DIFF
--- a/frontend/src/features/notes/hooks/useNoteEditor.tsx
+++ b/frontend/src/features/notes/hooks/useNoteEditor.tsx
@@ -171,7 +171,8 @@ export const useNoteEditor = ({
   useEffect(() => {
     if (!debouncedContent || !projectId || !editor) return;
     const tags = extractTagsFromText(debouncedContent);
-    if (tags.length === 0) {
+    const limitedTags = tags.slice(0, 5); // タグを最大5件までに制限
+    if (limitedTags.length === 0) {
       setMatchingNoteInfos([]);
       // @ts-ignore
       editor.commands.setMatchingNoteInfos([]);
@@ -182,7 +183,8 @@ export const useNoteEditor = ({
         .from('notes')
         .select('title, url_id')
         .eq('project_id', projectId)
-        .in('title', tags);
+        .in('title', limitedTags)
+        .limit(15); // ノートを最大15件までに制限
       if (error) {
         setMatchingNoteInfos([]);
         // @ts-ignore


### PR DESCRIPTION
# やったこと
- ノート取得件数に上限を設けた（１５件）
- ページネーションは未実装

# 結果
テスト用に絞った結果
![image](https://github.com/user-attachments/assets/6648faef-02e9-4250-bf1c-339ec2352989)
