### PR TITLE
ビルドエラーの解消

### DIFF
--- a/frontend/src/app/(private)/projects/[projectUrlId]/notes/[noteUrlId]/page.tsx
+++ b/frontend/src/app/(private)/projects/[projectUrlId]/notes/[noteUrlId]/page.tsx
@@ -4,16 +4,14 @@ import { getProjectByUrlId } from '@/lib/api/project';
 import { notFound } from 'next/navigation';
 
 type NotePageProps = {
-  params: {
+  params: Promise<{
     projectUrlId: string;
     noteUrlId: string;
-  };
+  }>;
 };
 
 const NotePage = async ({ params }: NotePageProps) => {
-  // paramsオブジェクト自体をawaitする
-  const resolvedParams = await params;
-  const { projectUrlId, noteUrlId } = resolvedParams;
+  const { projectUrlId, noteUrlId } = await params;
 
   // urlIdからプロジェクトを取得
   const projectData = await getProjectByUrlId(projectUrlId);

--- a/frontend/src/app/(private)/projects/[projectUrlId]/notes/new/page.tsx
+++ b/frontend/src/app/(private)/projects/[projectUrlId]/notes/new/page.tsx
@@ -3,15 +3,13 @@ import { getProjectByUrlId } from '@/lib/api/project';
 import { notFound } from 'next/navigation';
 
 type NewNotePageProps = {
-  params: {
+  params: Promise<{
     projectUrlId: string;
-  };
+  }>;
 };
 
 const NewNotePage = async ({ params }: NewNotePageProps) => {
-  // paramsオブジェクト自体をawaitする
-  const resolvedParams = await params;
-  const projectUrlId = resolvedParams.projectUrlId;
+  const { projectUrlId } = await params;
 
   // urlIdからプロジェクトを取得
   const projectData = await getProjectByUrlId(projectUrlId);

--- a/frontend/src/app/(private)/projects/[projectUrlId]/notes/page.tsx
+++ b/frontend/src/app/(private)/projects/[projectUrlId]/notes/page.tsx
@@ -5,15 +5,13 @@ import { createClient } from '@/utils/supabase/server';
 import { notFound } from 'next/navigation';
 
 type NoteListPageProps = {
-  params: {
+  params: Promise<{
     projectUrlId: string;
-  };
+  }>;
 };
 
 const NotesPage = async ({ params }: NoteListPageProps) => {
-  // paramsオブジェクト自体をawaitする
-  const resolvedParams = await params;
-  const projectUrlId = resolvedParams.projectUrlId;
+  const { projectUrlId } = await params;
 
   // サーバーコンポーネント用のSupabaseクライアントを作成
   const supabase = await createClient();

--- a/frontend/src/features/auth/components/Login/index.stories.tsx
+++ b/frontend/src/features/auth/components/Login/index.stories.tsx
@@ -108,7 +108,8 @@ export const GoogleOnly: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Googleログインのみ（メールアドレスとパスワードの入力フォーム非表示）',
+        story:
+          'Googleログインのみ（メールアドレスとパスワードの入力フォーム非表示）',
       },
     },
   },


### PR DESCRIPTION
# やったこと
- ビルドエラーを解消

# 結果
```
yarn build
  ▲ Next.js 15.0.1
  - Environments: .env.local

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types    
   Collecting page data  ..(node:225870) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:225833) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:225867) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 ✓ Collecting page data    
(node:225855) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:225949) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 ✓ Generating static pages (8/8)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization    

Route (app)                                     Size     First Load JS
┌ ○ /                                           493 B          99.5 kB
├ ○ /_not-found                                 897 B          99.9 kB
├ ○ /admin                                      3.01 kB         148 kB
├ ƒ /auth/callback                              140 B          99.2 kB
├ ○ /login                                      9.86 kB         155 kB
├ ƒ /projects/[projectUrlId]/notes              2.61 kB         156 kB
├ ƒ /projects/[projectUrlId]/notes/[noteUrlId]  1.27 kB         281 kB
└ ƒ /projects/[projectUrlId]/notes/new          945 B           281 kB
+ First Load JS shared by all                   99 kB
  ├ chunks/215-08d10c4f7e3cf0fb.js              44.5 kB
  ├ chunks/4bd1b696-23b0b206f2691055.js         52.6 kB
  └ other shared chunks (total)                 1.96 kB


ƒ Middleware                                    62.8 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```